### PR TITLE
Message list can be empty

### DIFF
--- a/library/ZendService/ZendServerAPI/Adapter/MessageList.php
+++ b/library/ZendService/ZendServerAPI/Adapter/MessageList.php
@@ -37,8 +37,15 @@ class MessageList extends Adapter
         if($xml === null)
             $xml = $this->getResponse()->getBody();
 
-        $xml = simplexml_load_string($xml);
         $messageList = new MessageListData();
+
+        $xml = trim($xml, PHP_EOL);
+        if (empty($xml)) {
+
+            return $messageList;
+        }
+
+        $xml = simplexml_load_string($xml);
         if(isset($xml->error))
             $messageList->setError((string) $xml->error);
         if(isset($xml->info))


### PR DESCRIPTION
Fixes an empty message list, which throws the following simplexml error:

simplexml_load_string(): Entity: line 2: parser error : Start tag expected, '<' not found [line 41 of /zendserver-phing/vendor/zendserverapi/zendserverapi/library/ZendService/ZendServerAPI/Adapter/MessageList.php]
simplexml_load_string():  [line 41 of /zendserver-phing/vendor/zendserverapi/zendserverapi/library/ZendService/ZendServerAPI/Adapter/MessageList.php]
simplexml_load_string(): ^ [line 41 of /zendserver-phing/vendor/zendserverapi/zendserverapi/library/ZendService/ZendServerAPI/Adapter/MessageList.php]

Change-Id: I912f57530ff7fc4f25cd30ac9c5144005419cad2
