### PR TITLE
refactored version specific base path to zendserver from method to request

### DIFF
--- a/library/ZendService/ZendServerAPI/Method/ApplicationRemove.php
+++ b/library/ZendService/ZendServerAPI/Method/ApplicationRemove.php
@@ -59,7 +59,7 @@ class ApplicationRemove extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/applicationRemove');
+        $this->setFunctionPath('/Api/applicationRemove');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ApplicationInfo());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/ApplicationRollback.php
+++ b/library/ZendService/ZendServerAPI/Method/ApplicationRollback.php
@@ -57,7 +57,7 @@ class ApplicationRollback extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/applicationRollback');
+        $this->setFunctionPath('/Api/applicationRollback');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ApplicationInfo());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/ApplicationSynchronize.php
+++ b/library/ZendService/ZendServerAPI/Method/ApplicationSynchronize.php
@@ -79,7 +79,7 @@ class ApplicationSynchronize extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/applicationSynchronize');
+        $this->setFunctionPath('/Api/applicationSynchronize');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ApplicationInfo());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/ClusterAddServer.php
+++ b/library/ZendService/ZendServerAPI/Method/ClusterAddServer.php
@@ -81,7 +81,7 @@ class ClusterAddServer extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/clusterAddServer');
+        $this->setFunctionPath('/Api/clusterAddServer');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ServerInfo());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/ClusterDisableServer.php
+++ b/library/ZendService/ZendServerAPI/Method/ClusterDisableServer.php
@@ -56,7 +56,7 @@ class ClusterDisableServer extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/clusterDisableServer');
+        $this->setFunctionPath('/Api/clusterDisableServer');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ServerInfo());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/ClusterEnableServer.php
+++ b/library/ZendService/ZendServerAPI/Method/ClusterEnableServer.php
@@ -57,7 +57,7 @@ class ClusterEnableServer extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/clusterEnableServer');
+        $this->setFunctionPath('/Api/clusterEnableServer');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ServerInfo());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/ClusterGetServerStatus.php
+++ b/library/ZendService/ZendServerAPI/Method/ClusterGetServerStatus.php
@@ -61,7 +61,7 @@ class ClusterGetServerStatus  extends Method
     public function configure()
     {
         $this->setMethod('GET');
-        $this->setFunctionPath('/ZendServerManager/Api/clusterGetServerStatus');
+        $this->setFunctionPath('/Api/clusterGetServerStatus');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ServersList());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/ClusterReconfigureServer.php
+++ b/library/ZendService/ZendServerAPI/Method/ClusterReconfigureServer.php
@@ -71,7 +71,7 @@ class ClusterReconfigureServer extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/clusterReconfigureServer');
+        $this->setFunctionPath('/Api/clusterReconfigureServer');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ServerInfo());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/ClusterRemoveServer.php
+++ b/library/ZendService/ZendServerAPI/Method/ClusterRemoveServer.php
@@ -64,7 +64,7 @@ class ClusterRemoveServer extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/clusterRemoveServer');
+        $this->setFunctionPath('/Api/clusterRemoveServer');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ServerInfo());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/CodetracingCreate.php
+++ b/library/ZendService/ZendServerAPI/Method/CodetracingCreate.php
@@ -63,7 +63,7 @@ class CodetracingCreate extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/codetracingCreate');
+        $this->setFunctionPath('/Api/codetracingCreate');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\Codetrace());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/CodetracingDelete.php
+++ b/library/ZendService/ZendServerAPI/Method/CodetracingDelete.php
@@ -65,7 +65,7 @@ class CodetracingDelete extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/codetracingDelete');
+        $this->setFunctionPath('/Api/codetracingDelete');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\Codetrace());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/CodetracingDisable.php
+++ b/library/ZendService/ZendServerAPI/Method/CodetracingDisable.php
@@ -65,7 +65,7 @@ class CodetracingDisable extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/codetracingDisable');
+        $this->setFunctionPath('/Api/codetracingDisable');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\CodetracingStatus());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/CodetracingDownloadTraceFile.php
+++ b/library/ZendService/ZendServerAPI/Method/CodetracingDownloadTraceFile.php
@@ -67,7 +67,7 @@ class CodetracingDownloadTraceFile extends Method
      */
     public function configure()
     {
-        $this->setFunctionPath('/ZendServerManager/Api/codetracingDownloadTraceFile');
+        $this->setFunctionPath('/Api/codetracingDownloadTraceFile');
         $this->setMethod('GET');
         $this->setParser(new CodetracingDownloadTraceFileAdapter());
     }

--- a/library/ZendService/ZendServerAPI/Method/CodetracingEnable.php
+++ b/library/ZendService/ZendServerAPI/Method/CodetracingEnable.php
@@ -64,7 +64,7 @@ class CodetracingEnable extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/codetracingEnable');
+        $this->setFunctionPath('/Api/codetracingEnable');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\CodetracingStatus());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/CodetracingIsEnabled.php
+++ b/library/ZendService/ZendServerAPI/Method/CodetracingIsEnabled.php
@@ -54,7 +54,7 @@ class CodetracingIsEnabled extends Method
     public function configure ()
     {
         $this->setMethod('GET');
-        $this->setFunctionPath('/ZendServerManager/Api/codetracingIsEnabled');
+        $this->setFunctionPath('/Api/codetracingIsEnabled');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\CodetracingStatus());
     }
 }

--- a/library/ZendService/ZendServerAPI/Method/CodetracingList.php
+++ b/library/ZendService/ZendServerAPI/Method/CodetracingList.php
@@ -100,7 +100,7 @@ class CodetracingList extends Method
     public function configure ()
     {
         $this->setMethod('GET');
-        $this->setFunctionPath('/ZendServerManager/Api/codetracingList');
+        $this->setFunctionPath('/Api/codetracingList');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\CodetracingList());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/ConfigurationExport.php
+++ b/library/ZendService/ZendServerAPI/Method/ConfigurationExport.php
@@ -52,7 +52,7 @@ class ConfigurationExport extends Method
      */
     public function configure()
     {
-        $this->setFunctionPath('/ZendServerManager/Api/configurationExport');
+        $this->setFunctionPath('/Api/configurationExport');
         $this->setMethod('GET');
         $this->setParser(new ConfigExportAdapter());
     }

--- a/library/ZendService/ZendServerAPI/Method/ConfigurationImport.php
+++ b/library/ZendService/ZendServerAPI/Method/ConfigurationImport.php
@@ -54,7 +54,7 @@ class ConfigurationImport extends Method
      */
     public function configure()
     {
-        $this->setFunctionPath('/ZendServerManager/Api/configurationImport');
+        $this->setFunctionPath('/Api/configurationImport');
         $this->setMethod('POST');
         $this->setParser(new ServersList());
     }

--- a/library/ZendService/ZendServerAPI/Method/GetSystemInfo.php
+++ b/library/ZendService/ZendServerAPI/Method/GetSystemInfo.php
@@ -39,6 +39,11 @@ class GetSystemInfo extends Method
         return $this;
     }
 
+    public function getAcceptHeader()
+    {
+        return "application/vnd.zend.serverapi+xml;version=1.2";
+    }
+
     /**
      * Configures all needed information for the method implementation
      *
@@ -47,7 +52,7 @@ class GetSystemInfo extends Method
     public function configure()
     {
         $this->setMethod('GET');
-        $this->setFunctionPath('/ZendServerManager/Api/getSystemInfo');
+        $this->setFunctionPath('/Api/getSystemInfo');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\SystemInfo());
     }
 }

--- a/library/ZendService/ZendServerAPI/Method/JobqueueStatistics.php
+++ b/library/ZendService/ZendServerAPI/Method/JobqueueStatistics.php
@@ -45,7 +45,7 @@ class JobqueueStatistics extends Method
     public function configure ()
     {
         $this->setMethod('GET');
-        $this->setFunctionPath('/ZendServerManager/Api/jobqueueStatistics');
+        $this->setFunctionPath('/Api/jobqueueStatistics');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\DumpParser());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/Method.php
+++ b/library/ZendService/ZendServerAPI/Method/Method.php
@@ -106,7 +106,7 @@ abstract class Method implements PluginInterface
     /**
      * Setter for the function path
      *
-     * @param  string $functionPath <p>e.g. /ZendServerManager/Api/Foo</p>
+     * @param  string $functionPath <p>e.g. Api/Foo</p>
      * @return void
      */
     public function setFunctionPath($functionPath)
@@ -139,7 +139,7 @@ abstract class Method implements PluginInterface
      * Get result from parser
      *
      * @param string
-     * @return DataTypes\DataType
+     * @return \ZendService\ZendServerAPI\DataTypes\DataType
      */
     public function parseResponse($xml = null)
     {

--- a/library/ZendService/ZendServerAPI/Method/MonitorChangeIssueStatus.php
+++ b/library/ZendService/ZendServerAPI/Method/MonitorChangeIssueStatus.php
@@ -79,7 +79,7 @@ class MonitorChangeIssueStatus extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/monitorChangeIssueStatus');
+        $this->setFunctionPath('/Api/monitorChangeIssueStatus');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\Issue());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/MonitorExportIssueByEventsGroup.php
+++ b/library/ZendService/ZendServerAPI/Method/MonitorExportIssueByEventsGroup.php
@@ -61,7 +61,7 @@ class MonitorExportIssueByEventsGroup extends Method
      */
     public function configure()
     {
-        $this->setFunctionPath('/ZendServerManager/Api/monitorExportIssueByEventsGroup');
+        $this->setFunctionPath('/Api/monitorExportIssueByEventsGroup');
         $this->setMethod('GET');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\MonitorExportIssueByEventsGroup());
     }

--- a/library/ZendService/ZendServerAPI/Method/MonitorGetEventGroupDetails.php
+++ b/library/ZendService/ZendServerAPI/Method/MonitorGetEventGroupDetails.php
@@ -64,7 +64,7 @@ class MonitorGetEventGroupDetails extends Method
     public function configure ()
     {
         $this->setMethod('GET');
-        $this->setFunctionPath('/ZendServerManager/Api/monitorGetEventGroupDetails');
+        $this->setFunctionPath('/Api/monitorGetEventGroupDetails');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\EventsGroupDetails());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/MonitorGetIssuesDetails.php
+++ b/library/ZendService/ZendServerAPI/Method/MonitorGetIssuesDetails.php
@@ -56,7 +56,7 @@ class MonitorGetIssuesDetails extends Method
     public function configure ()
     {
         $this->setMethod('GET');
-        $this->setFunctionPath('/ZendServerManager/Api/monitorGetIssueDetails');
+        $this->setFunctionPath('/Api/monitorGetIssueDetails');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\IssueDetails());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/MonitorGetIssuesListByPredefinedFilter.php
+++ b/library/ZendService/ZendServerAPI/Method/MonitorGetIssuesListByPredefinedFilter.php
@@ -94,7 +94,7 @@ class MonitorGetIssuesListByPredefinedFilter extends Method
     public function configure ()
     {
         $this->setMethod('GET');
-        $this->setFunctionPath('/ZendServerManager/Api/monitorGetIssuesListPredefinedFilter');
+        $this->setFunctionPath('/Api/monitorGetIssuesListPredefinedFilter');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\IssueList());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/MonitorGetRequestSummary.php
+++ b/library/ZendService/ZendServerAPI/Method/MonitorGetRequestSummary.php
@@ -55,7 +55,7 @@ class MonitorGetRequestSummary extends Method
     public function configure ()
     {
         $this->setMethod('GET');
-        $this->setFunctionPath('/ZendServerManager/Api/monitorGetRequestSummary');
+        $this->setFunctionPath('/Api/monitorGetRequestSummary');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\RequestSummary());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/RestartPHP.php
+++ b/library/ZendService/ZendServerAPI/Method/RestartPHP.php
@@ -61,7 +61,7 @@ class RestartPHP extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/restartPhp');
+        $this->setFunctionPath('/Api/restartPhp');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\ServersList());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/StudioStartDebug.php
+++ b/library/ZendService/ZendServerAPI/Method/StudioStartDebug.php
@@ -73,7 +73,7 @@ class StudioStartDebug extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/studioStartDebug');
+        $this->setFunctionPath('/Api/studioStartDebug');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\DebugRequest());
     }
 

--- a/library/ZendService/ZendServerAPI/Method/StudioStartProfile.php
+++ b/library/ZendService/ZendServerAPI/Method/StudioStartProfile.php
@@ -65,7 +65,7 @@ class StudioStartProfile extends Method
     public function configure ()
     {
         $this->setMethod('POST');
-        $this->setFunctionPath('/ZendServerManager/Api/studioStartProfile');
+        $this->setFunctionPath('/Api/studioStartProfile');
         $this->setParser(new  \ZendService\ZendServerAPI\Adapter\DebugRequest());
     }
 

--- a/library/ZendService/ZendServerAPI/Request.php
+++ b/library/ZendService/ZendServerAPI/Request.php
@@ -316,9 +316,20 @@ class Request implements ServiceLocatorAwareInterface, LoggerAwareInterface, Plu
             ));
         }
         $request->getUri()->setScheme($this->config->getProtocol());
-        $request->getUri()->setPath($this->action->getLink());
+        $request->getUri()->setPath($this->getBasePath() . $this->action->getLink());
 
         return $request;
+    }
+
+    /**
+     * Returns the base path to ZendServer GUI.
+     *
+     * @return string
+     */
+    public function getBasePath()
+    {
+        // TODO add config check for ZendServer version
+        return '/ZendServer';
     }
 
     /**
@@ -360,6 +371,7 @@ class Request implements ServiceLocatorAwareInterface, LoggerAwareInterface, Plu
     private function generateRequestSignature($date)
     {
         $data = $this->config->getHost() . ":".$this->config->getPort().":" .
+                $this->getBasePath() .
                 $this->action->getFunctionPath() . ":" .
                 $this->userAgent . ":" .
                 $date;
@@ -373,7 +385,7 @@ class Request implements ServiceLocatorAwareInterface, LoggerAwareInterface, Plu
      * @param \Zend\ServiceManager\ServiceLocatorInterface
      * @return void
      */
-    public function setServicelocator (ServiceLocatorInterface $serviceLocator)
+    public function setServicelocator(ServiceLocatorInterface $serviceLocator)
     {
         $this->sl = $serviceLocator;
     }

--- a/tests/ZendServerAPITest/Integration/TestAssets/server/clusterAddServer
+++ b/tests/ZendServerAPITest/Integration/TestAssets/server/clusterAddServer
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 X-Powered-By: PHP/5.2.17 ZendServer/5.0
-Set-Cookie: ZENDSERVERSESSID=00pjdit3215o33s2s4rtrnsje3; path=/ZendServerManager
+Set-Cookie: ZENDSERVERSESSID=00pjdit3215o33s2s4rtrnsje3; path=/ZendServer
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 Pragma: no-cache

--- a/tests/ZendServerAPITest/Integration/TestAssets/server/clusterDisableServer
+++ b/tests/ZendServerAPITest/Integration/TestAssets/server/clusterDisableServer
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 X-Powered-By: PHP/5.2.17 ZendServer/5.0
-Set-Cookie: ZENDSERVERSESSID=tri257rl2303iaap6cn7skcti0; path=/ZendServerManager
+Set-Cookie: ZENDSERVERSESSID=tri257rl2303iaap6cn7skcti0; path=/ZendServer
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 Pragma: no-cache

--- a/tests/ZendServerAPITest/Integration/TestAssets/server/clusterEnableServer
+++ b/tests/ZendServerAPITest/Integration/TestAssets/server/clusterEnableServer
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 X-Powered-By: PHP/5.2.17 ZendServer/5.0
-Set-Cookie: ZENDSERVERSESSID=8mnisffb2dmiab1ua3se2u34k5; path=/ZendServerManager
+Set-Cookie: ZENDSERVERSESSID=8mnisffb2dmiab1ua3se2u34k5; path=/ZendServer
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 Pragma: no-cache

--- a/tests/ZendServerAPITest/Integration/TestAssets/server/clusterGetServerStatus
+++ b/tests/ZendServerAPITest/Integration/TestAssets/server/clusterGetServerStatus
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 X-Powered-By: PHP/5.2.17 ZendServer/5.0
-Set-Cookie: ZENDSERVERSESSID=4ubenp051g39r9duhhd30s5mk3; path=/ZendServerManager
+Set-Cookie: ZENDSERVERSESSID=4ubenp051g39r9duhhd30s5mk3; path=/ZendServer
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 Pragma: no-cache

--- a/tests/ZendServerAPITest/Integration/TestAssets/server/clusterReconfigureServer
+++ b/tests/ZendServerAPITest/Integration/TestAssets/server/clusterReconfigureServer
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 X-Powered-By: PHP/5.2.17 ZendServer/5.0
-Set-Cookie: ZENDSERVERSESSID=anuvu0qdf6b9n00e0ln896n4e4; path=/ZendServerManager
+Set-Cookie: ZENDSERVERSESSID=anuvu0qdf6b9n00e0ln896n4e4; path=/ZendServer
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 Pragma: no-cache

--- a/tests/ZendServerAPITest/Integration/TestAssets/server/clusterRemoveServer
+++ b/tests/ZendServerAPITest/Integration/TestAssets/server/clusterRemoveServer
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 X-Powered-By: PHP/5.2.17 ZendServer/5.0
-Set-Cookie: ZENDSERVERSESSID=1kgtnpkjteoranceq92a1169s1; path=/ZendServerManager
+Set-Cookie: ZENDSERVERSESSID=1kgtnpkjteoranceq92a1169s1; path=/ZendServer
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 Pragma: no-cache

--- a/tests/ZendServerAPITest/Integration/TestAssets/server/restartPhp
+++ b/tests/ZendServerAPITest/Integration/TestAssets/server/restartPhp
@@ -1,6 +1,6 @@
 HTTP/1.1 202 Accepted
 X-Powered-By: PHP/5.2.17 ZendServer/5.0
-Set-Cookie: ZENDSERVERSESSID=bh3kh3jnd992ekru6e4jolb2l1; path=/ZendServerManager
+Set-Cookie: ZENDSERVERSESSID=bh3kh3jnd992ekru6e4jolb2l1; path=/ZendServer
 Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 Pragma: no-cache

--- a/tests/ZendServerAPITest/Method/ApplicationGetStatusTest.php
+++ b/tests/ZendServerAPITest/Method/ApplicationGetStatusTest.php
@@ -10,7 +10,7 @@ class ApplicationGetStatusTest extends \PHPUnit_Framework_TestCase
         $method = new \ZendService\ZendServerAPI\Method\ApplicationGetStatus();
         $method->setArgs(array(1,2));
 
-       $this->assertEquals("/ZendServerManager/Api/applicationGetStatus?applications%5B0%5D=1&applications%5B1%5D=2", $method->getLink());
+       $this->assertEquals("/Api/applicationGetStatus?applications%5B0%5D=1&applications%5B1%5D=2", $method->getLink());
     }
     
     public static function getResponse()

--- a/tests/ZendServerAPITest/Method/ClusterDisableServerTest.php
+++ b/tests/ZendServerAPITest/Method/ClusterDisableServerTest.php
@@ -66,7 +66,7 @@ EOF;
         $action = new \ZendService\ZendServerAPI\Method\ClusterDisableServer();
         $action->setArgs(self::getParameter());
     
-        $this->assertEquals("/ZendServerManager/Api/clusterDisableServer", $action->getLink());
+        $this->assertEquals("/Api/clusterDisableServer", $action->getLink());
     }
     
     public function testRequestBody()

--- a/tests/ZendServerAPITest/Method/ClusterEnableServerTest.php
+++ b/tests/ZendServerAPITest/Method/ClusterEnableServerTest.php
@@ -66,7 +66,7 @@ EOF;
         $action = new \ZendService\ZendServerAPI\Method\ClusterEnableServer();
         $action->setArgs(self::getParameter());
     
-        $this->assertEquals("/ZendServerManager/Api/clusterEnableServer", $action->getLink());
+        $this->assertEquals("/Api/clusterEnableServer", $action->getLink());
     }
     
     public function testRequestBody()

--- a/tests/ZendServerAPITest/Method/ClusterGetServerStatusTest.php
+++ b/tests/ZendServerAPITest/Method/ClusterGetServerStatusTest.php
@@ -87,7 +87,7 @@ EOF;
         $action = new \ZendService\ZendServerAPI\Method\ClusterGetServerStatus();
         $action->setArgs(self::getParameters());
         
-        $this->assertEquals("/ZendServerManager/Api/clusterGetServerStatus?servers%5B0%5D=12&servers%5B1%5D=15", $action->getLink());
+        $this->assertEquals("/Api/clusterGetServerStatus?servers%5B0%5D=12&servers%5B1%5D=15", $action->getLink());
     }
 }
 

--- a/tests/ZendServerAPITest/Method/ClusterReconfigureServerTest.php
+++ b/tests/ZendServerAPITest/Method/ClusterReconfigureServerTest.php
@@ -68,7 +68,7 @@ EOF;
     {
         $action = new ClusterReconfigureServer();
         $action->setArgs(self::getParameter());
-        $this->assertEquals('/ZendServerManager/Api/clusterReconfigureServer', $action->getLink());
+        $this->assertEquals('/Api/clusterReconfigureServer', $action->getLink());
     }
     
     public function testContent()

--- a/tests/ZendServerAPITest/Method/ClusterRemoveServerTest.php
+++ b/tests/ZendServerAPITest/Method/ClusterRemoveServerTest.php
@@ -65,7 +65,7 @@ EOF;
         $action = new \ZendService\ZendServerAPI\Method\ClusterRemoveServer();
         $action->setArgs(self::getParameter());
     
-        $this->assertEquals("/ZendServerManager/Api/clusterRemoveServer", $action->getLink());
+        $this->assertEquals("/Api/clusterRemoveServer", $action->getLink());
     }
     
     public function testContent()

--- a/tests/ZendServerAPITest/Method/CodeTracingIsEnabledTest.php
+++ b/tests/ZendServerAPITest/Method/CodeTracingIsEnabledTest.php
@@ -13,7 +13,7 @@ class CodetracingIsEnabledTest extends \PHPUnit_Framework_TestCase
     public function testLink()
     {
         $codetraceIsEnableMethod = new \ZendService\ZendServerAPI\Method\CodetracingIsEnabled();
-        $this->assertEquals('/ZendServerManager/Api/codetracingIsEnabled', $codetraceIsEnableMethod->getLink());
+        $this->assertEquals('/Api/codetracingIsEnabled', $codetraceIsEnableMethod->getLink());
     }
     
     public function testMethod()

--- a/tests/ZendServerAPITest/Method/CodetracingDisableTest.php
+++ b/tests/ZendServerAPITest/Method/CodetracingDisableTest.php
@@ -31,7 +31,7 @@ class CodetracingDisableTest extends \PHPUnit_Framework_TestCase
     {
         $codetraceDisableMethod = new \ZendService\ZendServerAPI\Method\CodetracingDisable();
         $codetraceDisableMethod->setArgs();
-        $this->assertEquals('/ZendServerManager/Api/codetracingDisable', $codetraceDisableMethod->getLink());
+        $this->assertEquals('/Api/codetracingDisable', $codetraceDisableMethod->getLink());
     }
     
     public function testMethod()

--- a/tests/ZendServerAPITest/Method/CodetracingEnableTest.php
+++ b/tests/ZendServerAPITest/Method/CodetracingEnableTest.php
@@ -21,7 +21,7 @@ class CodetracingEnableTest extends \PHPUnit_Framework_TestCase
     {
         $codetraceEnableMethod = new \ZendService\ZendServerAPI\Method\CodetracingEnable();
         $codetraceEnableMethod->setArgs();
-        $this->assertEquals('/ZendServerManager/Api/codetracingEnable', $codetraceEnableMethod->getLink());
+        $this->assertEquals('/Api/codetracingEnable', $codetraceEnableMethod->getLink());
     }
     
     public function testMethod()

--- a/tests/ZendServerAPITest/Method/MethodImplementationTest.php
+++ b/tests/ZendServerAPITest/Method/MethodImplementationTest.php
@@ -22,7 +22,7 @@ class MethodImplementationTest extends \PHPUnit_Framework_TestCase {
 	{
 		$implementation = $this->getMock('\ZendService\ZendServerAPI\Method\GetSystemInfo', array('setMethod', 'setFunctionPath'));
 		$implementation->expects($this->once())->method('setMethod')->with('GET');
-		$implementation->expects($this->once())->method('setFunctionPath')->with('/ZendServerManager/Api/getSystemInfo');
+		$implementation->expects($this->once())->method('setFunctionPath')->with('/Api/getSystemInfo');
 		
 		$implementation->configure();
 	}
@@ -31,7 +31,7 @@ class MethodImplementationTest extends \PHPUnit_Framework_TestCase {
 	{
 	    $implementation = $this->getMock('\ZendService\ZendServerAPI\Method\ClusterGetServerStatus', array('setMethod', 'setFunctionPath'), array(ClusterGetServerStatusTest::getParameters()));
 	    $implementation->expects($this->once())->method('setMethod')->with('GET');
-	    $implementation->expects($this->once())->method('setFunctionPath')->with('/ZendServerManager/Api/clusterGetServerStatus');
+	    $implementation->expects($this->once())->method('setFunctionPath')->with('/Api/clusterGetServerStatus');
 	
 	    $implementation->configure();
 	}
@@ -40,7 +40,7 @@ class MethodImplementationTest extends \PHPUnit_Framework_TestCase {
 	{
 	    $implementation = $this->getMock('\ZendService\ZendServerAPI\Method\RestartPHP', array('setMethod', 'setFunctionPath'));
 	    $implementation->expects($this->once())->method('setMethod')->with('POST');
-	    $implementation->expects($this->once())->method('setFunctionPath')->with('/ZendServerManager/Api/restartPhp');
+	    $implementation->expects($this->once())->method('setFunctionPath')->with('/Api/restartPhp');
 	    
 	    $implementation->configure();
 	}

--- a/tests/ZendServerAPITest/Method/RestartTest.php
+++ b/tests/ZendServerAPITest/Method/RestartTest.php
@@ -90,7 +90,7 @@ EOF;
         $action = new \ZendService\ZendServerAPI\Method\RestartPHP();
         $action->setArgs(self::getParameter());
     
-        $this->assertEquals("/ZendServerManager/Api/restartPhp", $action->getLink());
+        $this->assertEquals("/Api/restartPhp", $action->getLink());
     }
     
     public function testContent()


### PR DESCRIPTION
and
changed default path from ZendServerManager (Version5) to ZendServer (Version 6)

Added a TODO as the base path is still hard coded, but now in one place (Request object) and does not switch depend on the ZendServer version
